### PR TITLE
make python version less strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Maksym.Tatariants <userboxj@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "3.10.12"
+python = "~3.10"
 numpy = "1.26"
 opencv-python = "~4.8"
 matplotlib = "~3.8"


### PR DESCRIPTION
We should consider making requirements less strict because not all users have exactly python version `3.10.12`. 